### PR TITLE
Update alexaspotify.class.php

### DIFF
--- a/core/class/alexaspotify.class.php
+++ b/core/class/alexaspotify.class.php
@@ -336,6 +336,9 @@ class alexaspotify extends eqLogic
     public function toHtml($_version = 'dashboard')
     {
         $replace = $this->preToHtml($_version);
+        if (!is_array($replace)) {
+            return $replace;
+        }	    
         //log::add('alexaspotify_widget','debug','************Début génération Widget de '.$replace['#logicalId#']);
         $typeWidget = "alexaapi";
         $typeWidget = $this->getLogicalId();
@@ -343,9 +346,7 @@ class alexaspotify extends eqLogic
         //if ((substr($replace['#logicalId#'], -9)) == "_playlist") $typeWidget = "alexaapi_playlist";
         if ($typeWidget != "alexaapi_playlist") return parent::toHtml($_version);
         //log::add('alexaspotify_widget','debug',$typeWidget.'************Début génération Widget de '.$replace['#name#']);
-        if (!is_array($replace)) {
-            return $replace;
-        }
+
         $version = jeedom::versionAlias($_version);
         if ($this->getDisplay('hideOn' . $version) == 1) {
             return '';


### PR DESCRIPTION
déplacement du bloc

```
	if (!is_array($replace)) {
		return $replace;
	}
```
pour éviter les PHP Warning dans http.error lorsque `$replace` n'est pas de type "array"